### PR TITLE
Fix format check

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,7 +38,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Check format & lint
-        run: make check
+        run: make lint
 
       - name: Run pytest
         run: make test


### PR DESCRIPTION
Close #4 

CIでlintチェックされる前に、formatされてしまっていたため、ｆormatされていないことを正しく検出出来ていなかったのを修正した