### PR TITLE
READMEの画像リンクを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ circuit_drawer(circuit, output_method="mpl")
 circuit_drawer(circuit, "mpl")
 ```
 
-![sample_circuit1.png](tests/images/simple_circuit1.png)
+![sample_circuit1.png](docs/source/_static/simple_circuit1.png)
 
 ## LaTeX Drawing
 


### PR DESCRIPTION
Close #58 

## 概要

参照していた画像ファイルが削除されたので、画像が表示できていませんでした。
ドキュメント用に用意していた画像を参照することで修正します。