### PR TITLE
:tada: Release 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qulacsvis"
-version = "0.2.2"
+version = "0.3.0"
 readme = "README.md"
 description = "visualizers for qulacs"
 repository = "https://github.com/Qulacs-Osaka/qulacs-visualizer"


### PR DESCRIPTION
## 概要

numpyのアップデートのために、Python 3.7のサポートを廃止することにしたため、バージョンを0.3.0にします。