### PR TITLE
Refactoring linter configs

### DIFF
--- a/qulacsvis/visualization/latex.py
+++ b/qulacsvis/visualization/latex.py
@@ -88,7 +88,8 @@ class LatexSourceGenerator:
         self._circuit = np.array([[] for _ in range(qubit_count)])
         for layer in range(circuit_layer_count):
             # This is an array containing strings.
-            # The string for each element is the string for the Qcircuit of the gate corresponding to each qubit row of the layer currently of interest.
+            # The string for each element is the string for the Qcircuit of the gate
+            # corresponding to each qubit row of the layer currently of interest.
             current_layer_latex = [to_latex_style("wire") for _ in range(qubit_count)]
             for qubit in range(qubit_count):
                 gate = self._circuit_data[qubit][layer]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
 [flake8]
 # e203: black treats : as a binary operator
 # e231: black doesn't put a space after ,
-# e501: black may exceed the line-length to follow other style rules
 # w503 or w504: either one needs to be disabled to select w error codes
-ignore = E203,E231,E501,W503
+ignore = E203,E231,W503
 select = B,B950,C,E,F,W
 per-file-ignores =
     # imported but unused
     __init__.py: F401
+max-line-length = 120
 
 [mypy]
 check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,24 +10,11 @@ per-file-ignores =
 max-line-length = 120
 
 [mypy]
-check_untyped_defs = True
-disallow_any_decorated = False
-disallow_any_generics = True
-disallow_any_unimported = False
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = False
-disallow_untyped_defs = True
-ignore_errors = False
-ignore_missing_imports = True
-no_implicit_optional = True
-python_version = 3.7
-show_error_codes = True
-strict_equality = True
-strict_optional = True
-warn_redundant_casts = True
-warn_return_any = True
+python_version = 3.8
+strict = True
 warn_unreachable = True
-warn_unused_configs = True
-warn_unused_ignores = True
+# Ignore errors when importing libraries that don't have a stub file (*.pyi) with type hints
+ignore_missing_imports = True
+show_error_codes = True
+# If `implicit_reexport = False`, you must explicitly add to `__all__` to re-export.
+implicit_reexport = True


### PR DESCRIPTION
## 概要

flake8, mypyの設定ファイルのリファクタリングを行いました。

- flake8 ではE501を無視するのではなく、代わりに`max-line-length`を使うようにしました
- mypyの`strict`で定義されるオプションがあるので、デフォルトで設定されるものは一覧から削除するようにしました