### PR TITLE
Do not force plt.show()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ circuit_drawer(circuit)
 To use another drawing method, you can specify it by setting a value to the `output_method` argument of the `circuit_drawer()` function. For matplotlib drawing, set `output_method="mpl"`.
 
 ```py
+import matplotlib.pyplot as plt
+
 circuit_drawer(circuit, "mpl")
+plt.show()
 ```
 
 ![circuit_matplotlib_drawing.png](doc/source/_static/circuit_matplotlib_drawing.png)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -76,7 +76,10 @@ Matplotlib Drawing
 
 To use another drawing method, you can specify it by setting a value to the ``output_method`` argument of the ``circuit_drawer()`` function. For matplotlib drawing, set ``output_method="mpl"``.
 
+>>> import matplotlib.pyplot as plt
+>>>
 >>> circuit_drawer(circuit, "mpl")
+>>> plt.show()
 
 .. figure:: _static/circuit_matplotlib_drawing.png
     :alt: circuit_matplotlib_drawing.png

--- a/qulacsvis/visualization/circuit_drawer.py
+++ b/qulacsvis/visualization/circuit_drawer.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from typing import Optional, Union
 
-import matplotlib.pyplot as plt
+import matplotlib  # NOQA
 from PIL import Image
 from qulacs import QuantumCircuit
 
@@ -22,7 +22,8 @@ def circuit_drawer(
     ppi: int = 150,
     dpi: int = 72,
     scale: float = 0.6,
-) -> Union[str, Image.Image, None]:
+) -> Union[str, Image.Image, matplotlib.figure.Figure]:
+
     """
     Draws a circuit diagram of a circuit.
 
@@ -121,9 +122,7 @@ def circuit_drawer(
 
     elif output_method == "mpl":
         mpl_drawer = MPLCircuitlDrawer(circuit, dpi=dpi, scale=scale)
-        mpl_drawer.draw()
-        plt.show()
-        return None
+        return mpl_drawer.draw()
 
     else:
         raise ValueError(

--- a/qulacsvis/visualization/matplotlib.py
+++ b/qulacsvis/visualization/matplotlib.py
@@ -17,6 +17,12 @@ from .circuit_parser import (
     GateData,
 )
 
+MATPLOTLIB_INLINE_BACKENDS = {
+    "module://ipykernel.pylab.backend_inline",
+    "module://matplotlib_inline.backend_inline",
+    "nbAgg",
+}
+
 GATE_MARGIN_RIGHT: Final[float] = 0.5
 GATE_MARGIN_LEFT: Final[float] = 0.5
 GATE_MARGIN_BOTTOM: Final[float] = 0.5
@@ -180,6 +186,8 @@ class MPLCircuitlDrawer:
             # Determine the x-coordinate of the next layer
             layer_xpos += self._parser.layer_width[layer] + GATE_MARGIN_RIGHT
 
+        if matplotlib.get_backend() in MATPLOTLIB_INLINE_BACKENDS:
+            matplotlib.pyplot.close(self._figure)
         return self._figure
 
     def _line(


### PR DESCRIPTION
- Close #101 

## 概要

Matplotlibを使った描画で、`plt.show()`を内部で実行しないようにしました。`plt.show()`を実行せずとも、JupyterNotebook上では従来どおり表示することが出来ますが、それ以外の場合はユーザが`plt.show()`を実行する必要がありますが、これはMatplotlibを使う上でも同じことです。