### PR TITLE
Use gate.name when LaTeX-style string is unavailable

### DIFF
--- a/qulacsvis/visualization/matplotlib.py
+++ b/qulacsvis/visualization/matplotlib.py
@@ -342,7 +342,10 @@ class MPLCircuitlDrawer:
         if gate.name == "":
             latex_style_gate_str = ""
         else:
-            latex_style_gate_str = f"${to_latex_style(gate.name)}$"
+            try:
+                latex_style_gate_str = f"${to_latex_style(gate.name)}$"
+            except KeyError:
+                latex_style_gate_str = gate.name
 
         self._text(xpos, ypos, latex_style_gate_str)
         self._control_bits(gate.control_bit_infos, (xpos, ypos))


### PR DESCRIPTION
I wanted to draw a gate whose name is not included in the standard LaTeX-style name mapping, so I made a change to catch `KeyError` and fallback to the original `gate.name`.