### PR TITLE
Adjust width of gate with its name containing new lines

### DIFF
--- a/qulacsvis/visualization/matplotlib.py
+++ b/qulacsvis/visualization/matplotlib.py
@@ -35,7 +35,8 @@ def _calc_gate_width(gate: GateData) -> float:
         to_latex_style(gate.name)
     except KeyError:
         char_width = 0.2
-        width += (len(gate.name) - 3) * char_width
+        max_line_width = max(len(s) for s in gate.name.splitlines())
+        width += (max_line_width - 3) * char_width
 
     return width
 


### PR DESCRIPTION
The width of the gate is computed based on length of the longest line in the gate name.