### PR TITLE
Made qulacs-visualizer work on Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["Qulacs-Osaka <you@example.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8"
 Qulacs = ">=0.5.0"
 temp = "^2020.7.2"
 Pillow = "^9.1.0"


### PR DESCRIPTION
Removed the dependancy of python < 3.12 in pyproject.toml

Since the project is entirely based on matplotlib and pillow, the Python 3.12 limit earlier set had no interference with actual visulaizer code. The library is working for Python 3.12

OS: Mac OS Seqouia
Python Version: Python 3.12.8
